### PR TITLE
Landing: chronosigil hero, elevated triptych, quiet coda

### DIFF
--- a/src/components/HeroSigil.astro
+++ b/src/components/HeroSigil.astro
@@ -1,217 +1,537 @@
 ---
 /**
- * Hero sigil: an alchemical instrument that visualizes "Matrix Alchemy".
- * Concentric rings of glyphs and matrix brackets orbit a pulsing core that
- * distills to a single gold node. Colors are theme variables, so the sigil
- * adapts to day and night. Motion is CSS-driven and yields to reduced-motion
- * via the global reset in global.css.
+ * Hero sigil — a chronosigil for "Matrix Alchemy".
+ *
+ * It doesn't tell the time; it *distills* it. One visual language throughout:
+ * every line is a sinusoid over an arc,
+ *   r(θ, t) = R + Σ Aᵢ(t) · sin(nᵢθ + φᵢ(t))
+ * and every amplitude Aᵢ(t) is itself a slow oscillator — the forms swell and
+ * subside, waves travel around the rings, and nothing ever rests. Few layers,
+ * distinct stroke weights:
+ *   - TRACK: a whisper-thin waveform circle on the outside — the day's path.
+ *   - DAY-ARC: the same waveform, drawn heavier over the elapsed fraction of
+ *     the 24h UTC day, its width breathing slowly; a sky glyph rides just
+ *     outside the gold "now" node (◑ dawn, ☉ day, ◐ dusk, ☾ night).
+ *   - NUMERALS (Futurist/Constructivist): each ring's number moves with its
+ *     ring — the hour laps the main ring once per 12h, the minute laps the
+ *     inner ring once per hour, the second orbits the core once per minute —
+ *     riding each ring's actual waveform, always upright, facing the reader.
+ *   - TOOLTIP: hovering the sigil fades in a plain mono readout under the
+ *     core (e.g. 22:04 UTC); it stays out of the art otherwise.
+ *   - FIGURE: two clean-stroked waveform rings. The main ring's harmonic
+ *     count is set by the UTC hour and crossfades to the next across the
+ *     hour; its stroke-width breathes over time and throbs with each real
+ *     second — the sinusoid itself stays pure, only the whole line's weight
+ *     changes. A hairline inner ring counters it.
+ *   - MATRIX: a faint phyllotaxis point-field behind everything, for depth.
+ *   - CORE: a constant gold node breathes at center — the distillate.
+ *
+ * Everything is computed client-side from real UTC at native frame rate; the
+ * server render seeds a composed default so no-JS / pre-hydration still reads
+ * as a finished instrument. Colors are theme tokens (day/night aware); motion
+ * yields to reduced-motion (a single static snapshot).
  */
 interface Props {
   class?: string;
 }
 const { class: cls = "" } = Astro.props;
 
-// Glyph ring: metals and operators, the two languages of the brief.
-const glyphs = [
-  { t: "Au", x: 480, y: 280, fill: "var(--gold)" },
-  { t: "Ag", x: 421, y: 421, fill: "var(--muted)" },
-  { t: "Ξ", x: 280, y: 480, fill: "var(--accent)" },
-  { t: "∇", x: 139, y: 421, fill: "var(--muted)" },
-  { t: "λ", x: 80, y: 280, fill: "var(--muted)" },
-  { t: "Σ", x: 139, y: 139, fill: "var(--accent)" },
-  { t: "π", x: 280, y: 80, fill: "var(--muted)" },
-  { t: "∂", x: 421, y: 139, fill: "var(--muted)" },
+const CX = 280;
+const CY = 280;
+const D2R = Math.PI / 180;
+const TAU = Math.PI * 2;
+const polar = (r: number, deg: number): [number, number] => [
+  +(CX + r * Math.cos((deg - 90) * D2R)).toFixed(2),
+  +(CY + r * Math.sin((deg - 90) * D2R)).toFixed(2),
 ];
+
+const R_DAY = 208;
+
+// The "matrix": a faint phyllotaxis point-field for depth + slow motion.
+const GOLDEN = Math.PI * (3 - Math.sqrt(5));
+const field = Array.from({ length: 110 }, (_, i) => {
+  const r = 14.6 * Math.sqrt(i);
+  const th = i * GOLDEN;
+  return {
+    x: +(CX + r * Math.cos(th)).toFixed(1),
+    y: +(CY + r * Math.sin(th)).toFixed(1),
+    op: +Math.max(0.04, 0.22 * (1 - r / 190)).toFixed(3),
+    r: +Math.max(0.55, 1.5 - r / 170).toFixed(2),
+    fill: i < 3 ? "var(--gold)" : "var(--accent)",
+  };
+});
+
+// A closed ring as sinusoids over the circle. Shared shape: SSR + client.
+type Harmonic = { n: number; amp: number; phase: number };
+function waveRing(R: number, harmonics: Harmonic[], N: number): string {
+  const out: string[] = [];
+  for (let i = 0; i <= N; i++) {
+    const th = (i / N) * TAU;
+    let r = R;
+    for (const h of harmonics) r += h.amp * Math.sin(h.n * th + h.phase);
+    out.push(
+      `${(CX + r * Math.cos(th)).toFixed(1)},${(CY + r * Math.sin(th)).toFixed(1)}`
+    );
+  }
+  return out.join(" ");
+}
+
+// An open arc as a single sinusoid — the track and the day-arc share this.
+function waveArc(
+  R: number,
+  n: number,
+  amp: number,
+  phase: number,
+  fromDeg: number,
+  toDeg: number,
+  N: number
+): string {
+  let d = "";
+  for (let i = 0; i <= N; i++) {
+    const ang = fromDeg + (i / N) * (toDeg - fromDeg);
+    const r = R + amp * Math.sin(n * ang * D2R + phase);
+    const [x, y] = polar(r, ang);
+    d += `${i ? "L" : "M"} ${x} ${y} `;
+  }
+  return d;
+}
+
+// The radius of a waveform ring at one display angle (0° = top), so moving
+// numerals can ride their ring's actual crest instead of floating.
+function ringRAt(R: number, harmonics: Harmonic[], deg: number): number {
+  const th = (deg - 90) * D2R;
+  let r = R;
+  for (const h of harmonics) r += h.amp * Math.sin(h.n * th + h.phase);
+  return r;
+}
+
+// SSR defaults: mid-swell so the pre-JS frame is already alive.
+const H1D: Harmonic[] = [
+  { n: 7, amp: 11, phase: 0.8 },
+  { n: 8, amp: 5, phase: -1.1 },
+  { n: 3, amp: -3.5, phase: 0.5 },
+];
+const H2D: Harmonic[] = [
+  { n: 9, amp: 7, phase: 2.1 },
+  { n: 2, amp: 3.5, phase: 1.0 },
+];
+const ring1Default = waveRing(150, H1D, 240);
+const ring2Default = waveRing(104, H2D, 200);
+const trackDefault = waveArc(R_DAY, 7, 2.2, 0.4, 0, 360, 240);
+const dayArcDefault = waveArc(R_DAY, 7, 2.2, 0.4, 0, 96, 72);
+const dnR = R_DAY + 2.2 * Math.sin(7 * 96 * D2R + 0.4);
+const [dnx, dny] = polar(dnR, 96);
+// The default moment is 96° into the day = 06:24 UTC — dawn.
+const [skyx, skyy] = polar(234, 96);
+const skyDefault = "◑";
+const utcDefault = "06:24 UTC";
+// Kinetic numerals at that moment: 06 on the hour ring (192° of its 12h lap),
+// 24 on the minute ring (144°), 00 on the core orbit (0°).
+const [hhx, hhy] = polar(ringRAt(150, H1D, 192) + 16, 192);
+const [mmx, mmy] = polar(ringRAt(104, H2D, 144) + 13, 144);
+const [ssx, ssy] = polar(41, 0);
 ---
 
 <svg
+  id="cs-svg"
   viewBox="0 0 560 560"
   class={`hero-sigil ${cls}`}
   role="img"
-  aria-label="An alchemical instrument distilling a matrix into a single gold node"
+  aria-label="A generative instrument distilling the current UTC moment to a single gold node"
   xmlns="http://www.w3.org/2000/svg"
 >
   <defs>
-    <radialGradient id="coreGlow" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="var(--accent)" style="stop-opacity: var(--glow-accent)"></stop>
-      <stop offset="100%" stop-color="var(--accent)" stop-opacity="0"></stop>
-    </radialGradient>
-    <radialGradient id="goldGlow" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="var(--gold)" style="stop-opacity: var(--glow-gold)"></stop>
+    <radialGradient id="csGold" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="var(--gold)" style="stop-opacity: var(--glow-gold)"
+      ></stop>
       <stop offset="100%" stop-color="var(--gold)" stop-opacity="0"></stop>
+    </radialGradient>
+    <radialGradient id="csAura" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="var(--accent)" style="stop-opacity: var(--glow-accent)"
+      ></stop>
+      <stop offset="70%" stop-color="var(--accent)" stop-opacity="0"></stop>
     </radialGradient>
   </defs>
 
-  <!-- flanking matrix brackets: the instrument is a bracketed matrix -->
-  <path
-    d="M40 198 H26 V362 H40"
-    stroke="var(--line-strong)"
-    stroke-width="2"
-    fill="none"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    opacity="0.5"></path>
-  <path
-    d="M520 198 H534 V362 H520"
-    stroke="var(--line-strong)"
-    stroke-width="2"
-    fill="none"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    opacity="0.5"></path>
+  <!-- soft emerald aura: one light source, for depth -->
+  <circle cx="280" cy="280" r="156" fill="url(#csAura)" opacity="0.3"></circle>
 
-  <!-- outer ring with ticks -->
-  <g class="orb spin-slow">
-    <circle
-      cx="280"
-      cy="280"
-      r="232"
-      fill="none"
-      stroke="var(--line-strong)"
-      stroke-width="1.4"
-      stroke-dasharray="2 22"></circle>
-    <circle cx="280" cy="48" r="3.4" fill="var(--accent)" class="twinkle"></circle>
-  </g>
-
-  <!-- glyph ring -->
-  <g class="orb glyphs">
+  <!-- the matrix: a faint point-field turning slowly behind everything -->
+  <g class="cs-field">
     {
-      glyphs.map((g) => (
-        <text
-          x={g.x}
-          y={g.y}
-          fill={g.fill}
-          font-family="var(--font-mono)"
-          font-size="21"
-          text-anchor="middle"
-          dominant-baseline="central"
-          opacity="0.9"
-        >
-          {g.t}
-        </text>
+      field.map((p) => (
+        <circle cx={p.x} cy={p.y} r={p.r} fill={p.fill} opacity={p.op} />
       ))
     }
   </g>
 
-  <!-- mid dashed ring -->
-  <g class="orb spin-mid">
-    <circle
-      cx="280"
-      cy="280"
-      r="160"
-      fill="none"
-      stroke="var(--accent)"
-      stroke-width="1.4"
-      stroke-dasharray="11 17"
-      opacity="0.55"></circle>
-    <circle cx="440" cy="280" r="3" fill="var(--gold)" class="twinkle"></circle>
-  </g>
+  <!-- flanking matrix brackets: the instrument is a bracketed matrix -->
+  <path
+    d="M44 196 H30 V364 H44"
+    stroke="var(--line-strong)"
+    stroke-width="2"
+    fill="none"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    opacity="0.5"></path>
+  <path
+    d="M516 196 H530 V364 H516"
+    stroke="var(--line-strong)"
+    stroke-width="2"
+    fill="none"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    opacity="0.5"></path>
 
-  <!-- inner bracket arcs framing the core -->
-  <g class="orb spin-in">
-    <path
-      d="M192 200 A112 112 0 0 0 192 360"
-      fill="none"
-      stroke="var(--accent)"
-      stroke-width="2"
-      stroke-linecap="round"
-      opacity="0.7"></path>
-    <path
-      d="M368 200 A112 112 0 0 1 368 360"
-      fill="none"
-      stroke="var(--accent)"
-      stroke-width="2"
-      stroke-linecap="round"
-      opacity="0.7"></path>
-  </g>
+  <!-- the figure: two waveform rings; the main one's stroke-width breathes -->
+  <polyline
+    id="cs-ring2"
+    points={ring2Default}
+    fill="none"
+    stroke="var(--accent)"
+    stroke-width="0.7"
+    stroke-linejoin="round"
+    opacity="0.35"></polyline>
+  <polyline
+    id="cs-ring1"
+    points={ring1Default}
+    fill="none"
+    stroke="var(--accent)"
+    stroke-width="1.6"
+    stroke-linejoin="round"
+    opacity="0.5"></polyline>
 
-  <!-- core: pulsing halo, ring, and the gold transmutation node -->
-  <circle cx="280" cy="280" r="58" fill="url(#coreGlow)" class="anchor core-halo"
+  <!-- the day's path: a whisper-thin waveform track... -->
+  <path
+    id="cs-track"
+    d={trackDefault}
+    fill="none"
+    stroke="var(--line-strong)"
+    stroke-width="1"
+    stroke-linejoin="round"
+    opacity="0.28"></path>
+
+  <!-- ...and the elapsed fraction of the UTC day, drawn heavier over it -->
+  <path
+    id="cs-dayarc"
+    d={dayArcDefault}
+    fill="none"
+    stroke="var(--accent)"
+    stroke-width="2.2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    opacity="0.65"></path>
+
+  <!-- the gold "now" on the day-arc's leading edge, with the sky above it:
+       whatever the UTC sky is doing this moment (◑ dawn, ☉ day, ◐ dusk, ☾ night) -->
+  <circle id="cs-daynode" cx={dnx} cy={dny} r="4.6" fill="var(--gold)" class="cs-daynode"
   ></circle>
+  <text
+    id="cs-sky"
+    class="cs-mono"
+    x={skyx}
+    y={skyy}
+    font-size="13"
+    fill="var(--fg-soft)"
+    opacity="0.7"
+    text-anchor="middle"
+    dominant-baseline="central">{skyDefault}</text
+  >
+
+  <!-- kinetic numerals: each ring's number moves with its ring. The hour laps
+       the main ring in 12h, the minute laps the inner ring in 1h, the second
+       orbits the core in 60s — riding each waveform, always upright. -->
+  <text
+    id="cs-hh"
+    class="cs-mono"
+    x={hhx}
+    y={hhy}
+    font-size="13"
+    letter-spacing="1"
+    fill="var(--fg-soft)"
+    opacity="0.7"
+    text-anchor="middle"
+    dominant-baseline="central">06</text
+  >
+  <text
+    id="cs-mm"
+    class="cs-mono"
+    x={mmx}
+    y={mmy}
+    font-size="11.5"
+    letter-spacing="1"
+    fill="var(--fg-soft)"
+    opacity="0.6"
+    text-anchor="middle"
+    dominant-baseline="central">24</text
+  >
+  <text
+    id="cs-ss"
+    class="cs-mono"
+    x={ssx}
+    y={ssy}
+    font-size="9.5"
+    letter-spacing="1"
+    fill="var(--accent)"
+    opacity="0.75"
+    text-anchor="middle"
+    dominant-baseline="central">00</text
+  >
+
+  <!-- core: a breathing gold halo, a thin emerald ring, and the distilled node -->
+  <circle cx="280" cy="280" r="52" fill="url(#csGold)" class="cs-core"></circle>
   <circle
     cx="280"
     cy="280"
-    r="36"
+    r="30"
     fill="none"
     stroke="var(--accent)"
-    stroke-width="1.5"
-    opacity="0.6"></circle>
-  <line
-    x1="280"
-    y1="280"
-    x2="280"
-    y2="232"
-    stroke="var(--accent)"
-    stroke-width="2"
-    stroke-linecap="round"
-    class="spark"></line>
-  <circle cx="280" cy="280" r="22" fill="url(#goldGlow)" class="anchor gold-halo"
-  ></circle>
-  <circle cx="280" cy="280" r="11" fill="var(--gold)"></circle>
+    stroke-width="1.2"
+    opacity="0.5"></circle>
+  <circle cx="280" cy="280" r="9" fill="var(--gold)"></circle>
+
+  <!-- the moment, stated plainly — but only when asked: fades in on hover -->
+  <text
+    id="cs-utc"
+    class="cs-mono cs-utc"
+    x="280"
+    y="352"
+    font-size="11"
+    fill="var(--muted)"
+    text-anchor="middle"
+    letter-spacing="2.2">{utcDefault}</text
+  >
 </svg>
 
 <style>
-  .orb,
-  .anchor {
-    transform-box: fill-box;
-    transform-origin: center;
+  .cs-core {
+    transform-box: view-box;
+    transform-origin: 280px 280px;
+    animation: cs-breathe 6.5s ease-in-out infinite;
   }
-  .spin-slow {
-    animation: spin 64s linear infinite;
+  .cs-field {
+    transform-box: view-box;
+    transform-origin: 280px 280px;
+    animation: cs-spin 220s linear infinite;
   }
-  .glyphs {
-    animation: spin 96s linear infinite reverse;
+  .cs-daynode {
+    filter: drop-shadow(0 0 5px color-mix(in oklab, var(--gold) 70%, transparent));
   }
-  .spin-mid {
-    animation: spin 46s linear infinite reverse;
+  .cs-mono {
+    font-family: "Spline Sans Mono Variable", ui-monospace, monospace;
   }
-  .spin-in {
-    animation: spin 34s linear infinite;
+  .cs-utc {
+    opacity: 0;
+    transition: opacity 0.35s ease;
   }
-  .core-halo {
-    animation: breathe 6.5s ease-in-out infinite;
+  svg:hover .cs-utc {
+    opacity: 0.85;
   }
-  .gold-halo {
-    animation: breathe 4.5s ease-in-out infinite;
-  }
-  .spark {
-    animation: rise 5s ease-in-out infinite;
-  }
-  .twinkle {
-    animation: tw 5.6s ease-in-out infinite;
-  }
-  @keyframes spin {
+  @keyframes cs-spin {
     to {
       transform: rotate(360deg);
     }
   }
-  @keyframes breathe {
-    0%,
-    100% {
-      opacity: 0.5;
-      transform: scale(1);
-    }
-    50% {
-      opacity: 0.95;
-      transform: scale(1.07);
-    }
-  }
-  @keyframes rise {
-    0%,
-    100% {
-      opacity: 0.15;
-    }
-    50% {
-      opacity: 0.85;
-    }
-  }
-  @keyframes tw {
+  @keyframes cs-breathe {
     0%,
     100% {
       opacity: 0.55;
+      transform: scale(1);
     }
     50% {
       opacity: 1;
+      transform: scale(1.06);
     }
   }
 </style>
+
+<script>
+  const svg = document.getElementById("cs-svg");
+  if (svg) {
+    const CX = 280;
+    const CY = 280;
+    const TAU = Math.PI * 2;
+    const D2R = Math.PI / 180;
+    const R_DAY = 208;
+    const polar = (r: number, deg: number) => [
+      CX + r * Math.cos((deg - 90) * D2R),
+      CY + r * Math.sin((deg - 90) * D2R),
+    ];
+    const f = (n: number) => n.toFixed(1);
+    const q = (id: string) => svg.querySelector<SVGElement>("#" + id);
+
+    const ring1 = q("cs-ring1");
+    const ring2 = q("cs-ring2");
+    const track = q("cs-track");
+    const dayarc = q("cs-dayarc");
+    const daynode = q("cs-daynode");
+    const sky = q("cs-sky");
+    const utc = q("cs-utc");
+    const hh = q("cs-hh");
+    const mm = q("cs-mm");
+    const ss = q("cs-ss");
+
+    type Harmonic = { n: number; amp: number; phase: number };
+    function waveRing(R: number, harmonics: Harmonic[], N: number) {
+      let out = "";
+      for (let i = 0; i <= N; i++) {
+        const th = (i / N) * TAU;
+        let r = R;
+        for (const h of harmonics) r += h.amp * Math.sin(h.n * th + h.phase);
+        out += `${(CX + r * Math.cos(th)).toFixed(1)},${(CY + r * Math.sin(th)).toFixed(1)} `;
+      }
+      return out;
+    }
+
+    function waveArc(
+      R: number,
+      n: number,
+      amp: number,
+      phase: number,
+      fromDeg: number,
+      toDeg: number,
+      N: number
+    ) {
+      let d = "";
+      for (let i = 0; i <= N; i++) {
+        const ang = fromDeg + (i / N) * (toDeg - fromDeg);
+        const r = R + amp * Math.sin(n * ang * D2R + phase);
+        const [x, y] = polar(r, ang);
+        d += `${i ? "L" : "M"} ${f(x)} ${f(y)} `;
+      }
+      return d;
+    }
+
+    // ring radius at one display angle, so numerals ride their waveform
+    function ringRAt(R: number, harmonics: Harmonic[], deg: number) {
+      const th = (deg - 90) * D2R;
+      let r = R;
+      for (const h of harmonics) r += h.amp * Math.sin(h.n * th + h.phase);
+      return r;
+    }
+
+    const p2 = (n: number) => String(n).padStart(2, "0");
+    // numerals orbit their rings but always stay upright, facing the reader
+    const setNum = (
+      el: SVGElement | null,
+      text: string,
+      deg: number,
+      r: number
+    ) => {
+      if (!el) return;
+      const [x, y] = polar(r, deg);
+      el.setAttribute("x", f(x));
+      el.setAttribute("y", f(y));
+      if (el.textContent !== text) el.textContent = text;
+    };
+
+    function update() {
+      const now = new Date();
+      const h = now.getUTCHours();
+      const m = now.getUTCMinutes();
+      const s = now.getUTCSeconds();
+      const ms = now.getUTCMilliseconds();
+      const t = ((h * 60 + m) * 60 + s) + ms / 1000; // seconds of the UTC day
+
+      // amplitude envelopes: slow oscillators on incommensurate periods, kept
+      // off the floor so the figure never flattens or stalls
+      const e1 = 0.55 + 0.45 * Math.sin((TAU * t) / 9.7);
+      const e2 = Math.sin((TAU * t) / 14.3 + 1.2);
+      const e3 = 0.55 + 0.45 * Math.sin((TAU * t) / 7.3 + 2.4);
+      const e4 = Math.sin((TAU * t) / 18.1 + 0.6);
+      const eT = 0.65 + 0.35 * Math.sin((TAU * t) / 23.7 + 0.9);
+      const shim = Math.sin((TAU * t) / 3.4); // fast micro-shimmer
+
+      // each real second, a throb through the ribbon's width: rises from
+      // zero, peaks early, decays — continuous at the boundary, never a snap
+      const u = ms / 1000;
+      const pulse = 8 * u * Math.exp(-4 * u);
+
+      const uHr = (m + s / 60 + ms / 60000) / 60; // hour fraction, crossfade
+      const nA = 5 + (h % 6); // main harmonic count, one per UTC hour
+      const phiA = TAU * ((t % 31) / 31);
+      const phiB = -TAU * ((t % 23) / 23);
+      const phiT = TAU * ((t % 61) / 61);
+
+      const H1: Harmonic[] = [
+        { n: nA, amp: 13 * e1 * (1 - uHr), phase: phiA },
+        { n: nA + 1, amp: 13 * e1 * uHr, phase: -phiA * 1.4 },
+        { n: 3, amp: 5.5 * e2, phase: phiA * 0.6 },
+        { n: 2 * nA + 1, amp: 1.3 * shim, phase: -phiA * 2 },
+      ];
+      const H2: Harmonic[] = [
+        { n: nA + 2, amp: 10 * e3, phase: phiB },
+        { n: 2, amp: 4 * e4, phase: phiB * 0.5 },
+      ];
+      ring1?.setAttribute("points", waveRing(150, H1, 240));
+      // the line's weight breathes as a whole — the sinusoid stays pure
+      ring1?.setAttribute(
+        "stroke-width",
+        (1.3 + 0.8 * e1 + 1.3 * pulse).toFixed(2)
+      );
+      ring2?.setAttribute("points", waveRing(104, H2, 200));
+
+      // energy shows as glow, but never dims to a stall
+      ring1?.setAttribute("opacity", (0.42 + 0.22 * e1).toFixed(2));
+      ring2?.setAttribute("opacity", (0.24 + 0.2 * e3).toFixed(2));
+
+      // the day's path — track and elapsed arc share one waveform, so the
+      // arc rides the track exactly; the gold "now" sits on its leading edge
+      const dayAngle = (t / 86400) * 360;
+      const ampT = 2.6 * eT;
+      track?.setAttribute("d", waveArc(R_DAY, 7, ampT, phiT, 0, 360, 240));
+      dayarc?.setAttribute(
+        "d",
+        waveArc(R_DAY, 7, ampT, phiT, 0, dayAngle, Math.max(12, Math.round(dayAngle / 1.5)))
+      );
+      dayarc?.setAttribute(
+        "stroke-width",
+        (2.1 + 0.5 * Math.sin((TAU * t) / 11.3 + 1)).toFixed(2)
+      );
+      const rNow = R_DAY + ampT * Math.sin(7 * dayAngle * D2R + phiT);
+      const [Dx, Dy] = polar(rNow, dayAngle);
+      daynode?.setAttribute("cx", f(Dx));
+      daynode?.setAttribute("cy", f(Dy));
+
+      // the symbols ARE the time: the sky glyph rides with "now" and shows
+      // what the UTC sky is doing this moment; the readout states it plainly
+      const [Gx, Gy] = polar(234, dayAngle);
+      sky?.setAttribute("x", f(Gx));
+      sky?.setAttribute("y", f(Gy));
+      const hf = h + m / 60;
+      const glyph =
+        hf < 5 ? "☾" : hf < 7 ? "◑" : hf < 17 ? "☉" : hf < 19 ? "◐" : "☾";
+      if (sky && sky.textContent !== glyph) {
+        sky.textContent = glyph;
+        sky.setAttribute(
+          "fill",
+          glyph === "☉" ? "var(--gold)" : "var(--fg-soft)"
+        );
+      }
+      const stamp = `${p2(h)}:${p2(m)} UTC`;
+      if (utc && utc.textContent !== stamp) utc.textContent = stamp;
+
+      // kinetic numerals: each number moves with — and rides — its own ring.
+      // Hour laps the main ring in 12h, minute laps the inner ring in 1h,
+      // second orbits the core in 60s.
+      const angH = (((h % 12) + m / 60 + s / 3600) / 12) * 360;
+      const angM = ((m + s / 60 + ms / 60000) / 60) * 360;
+      const angS = ((s + ms / 1000) / 60) * 360;
+      setNum(hh, p2(h), angH, ringRAt(150, H1, angH) + 16);
+      setNum(mm, p2(m), angM, ringRAt(104, H2, angM) + 13);
+      setNum(ss, p2(s), angS, 41);
+    }
+
+    update();
+    const motionOK = window.matchMedia(
+      "(prefers-reduced-motion: no-preference)"
+    ).matches;
+    if (motionOK) {
+      const loop = () => {
+        update();
+        requestAnimationFrame(loop);
+      };
+      requestAnimationFrame(loop);
+    }
+  }
+</script>

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -36,6 +36,15 @@ const plus = [
   [36, 24],
   [24, 36],
 ];
+
+// Status ("breathe") variant: a radial ripple. The gold core pulses and a
+// wave of light radiates outward through the dots (inner ring first, then the
+// corners) and fades, on repeat. Each element's delay is set by its distance
+// from center, so the pulse travels outward from the core.
+const RIPPLE_SPREAD = 0.8;
+const MAXD = Math.hypot(12, 12);
+const rippleDelay = (x: number, y: number) =>
+  (-(1 - Math.hypot(x - 24, y - 24) / MAXD) * RIPPLE_SPREAD).toFixed(2);
 ---
 
 <svg
@@ -50,14 +59,14 @@ const plus = [
   {title && <title>{title}</title>}
 
   <g class="rm-orbit">
-    {corners.map(([x, y]) => <circle cx={x} cy={y} r="2" fill="currentColor" opacity="0.85" class="rm-dot-c" />)}
-    {plus.map(([x, y]) => <circle cx={x} cy={y} r="2.9" fill="currentColor" class="rm-dot-p" />)}
+    {corners.map(([x, y]) => <circle cx={x} cy={y} r="2" fill="currentColor" opacity="0.85" class="rm-dot-c" style={`--d:${rippleDelay(x, y)}s`} />)}
+    {plus.map(([x, y]) => <circle cx={x} cy={y} r="2.9" fill="currentColor" class="rm-dot-p" style={`--d:${rippleDelay(x, y)}s`} />)}
   </g>
 
   {animated && plus.map(([x, y]) => <circle cx={x} cy={y} r="3.2" fill="none" stroke="var(--accent)" stroke-width="1.6" class="rm-ring-p" />)}
   {animated && corners.map(([x, y]) => <circle cx={x} cy={y} r="2.7" fill="none" stroke="var(--accent)" stroke-width="1.5" class="rm-ring-c" />)}
 
-  <circle cx="24" cy="24" r="4.3" fill="var(--gold)" class="rm-core" />
+  <circle cx="24" cy="24" r="4.3" fill="var(--gold)" class="rm-core" style={`--d:${rippleDelay(24, 24)}s`} />
 </svg>
 
 <style>
@@ -69,23 +78,42 @@ const plus = [
     transform-box: fill-box;
     transform-origin: center;
   }
-  /* Breathing variant: the matrix gently extends and retracts, the core beats.
-     Used as the footer's "at work" status glyph. */
-  .is-breathing .rm-orbit {
+  /* Status ("breathe") variant: a light sweeps around the matrix. Each dot
+     pulses on a delay set by its angle, so a bright point travels the ring
+     like a slow comet, while the gold core holds a steady glow. Reads as live
+     rotation, not a flat pulse. */
+  .is-breathing .rm-dot-c,
+  .is-breathing .rm-dot-p {
     transform-box: fill-box;
     transform-origin: center;
-    animation: rmOrbitExtend 2.4s ease-in-out infinite;
+    animation: rmRipple 2.4s ease-in-out infinite;
+    animation-delay: var(--d, 0s);
   }
   .is-breathing .rm-core {
-    animation: rmCoreBeat 2.4s ease-in-out infinite;
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: rmRippleCore 2.4s ease-in-out infinite;
+    animation-delay: var(--d, 0s);
   }
-  @keyframes rmOrbitExtend {
-    0%, 100% { scale: 1; }
-    50% { scale: 1.12; }
+  @keyframes rmRipple {
+    0%, 35%, 65%, 100% {
+      opacity: 0.3;
+      scale: 0.85;
+    }
+    50% {
+      opacity: 1;
+      scale: 1.22;
+    }
   }
-  @keyframes rmCoreBeat {
-    0%, 100% { opacity: 0.75; scale: 1; }
-    50% { opacity: 1; scale: 1.1; }
+  @keyframes rmRippleCore {
+    0%, 35%, 65%, 100% {
+      opacity: 0.7;
+      scale: 1;
+    }
+    50% {
+      opacity: 1;
+      scale: 1.3;
+    }
   }
   /* cross phase: plus dots become rings; diagonal phase: corners become rings */
   .is-animated .rm-dot-p {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,18 +8,23 @@ import HeroSigil from "../components/HeroSigil.astro";
 // thread of its own. Live sections link; the coming one is a statement.
 const threads = [
   {
+    n: "01",
     glyph: "Ξ",
     title: "The models",
     body: "How modern machine learning actually works, from attention and transformers to evaluation that holds up.",
     href: "/posts/",
+    cta: "Read ML/AI",
   },
   {
+    n: "02",
     glyph: "{ }",
     title: "The machines",
     body: "Engineering that ships. Pipelines, infrastructure, and the craft of running it in the real world.",
     href: "/dev/",
+    cta: "Read Dev",
   },
   {
+    n: "03",
     glyph: "⊕",
     title: "The ciphers",
     body: "Cryptography and the hard edges of systems built to be trusted.",
@@ -101,16 +106,22 @@ const threads = [
           t.href ? (
             <a
               href={t.href}
-              class="pillar group bg-bg px-1 py-12 sm:px-7 lg:py-14"
+              class="pillar group relative flex flex-col bg-bg px-6 py-12 sm:px-7 lg:px-8 lg:py-16"
             >
-              <div
-                class="pillar-glyph font-mono text-2xl text-gold"
-                aria-hidden="true"
-              >
-                {t.glyph}
+              <span class="pillar-accent" aria-hidden="true" />
+              <div class="flex items-start justify-between">
+                <span
+                  class="pillar-glyph font-mono text-2xl text-gold"
+                  aria-hidden="true"
+                >
+                  {t.glyph}
+                </span>
+                <span class="pillar-index font-mono text-[0.7rem] tracking-[0.24em] text-muted">
+                  {t.n}
+                </span>
               </div>
               <h2
-                class="pillar-title mt-5 font-display text-lg"
+                class="pillar-title mt-6 font-display text-lg"
                 style="font-weight:600"
               >
                 {t.title}
@@ -118,29 +129,52 @@ const threads = [
               <p class="mt-2.5 text-[0.95rem] leading-relaxed text-muted">
                 {t.body}
               </p>
+              <span class="pillar-cta mt-auto inline-flex items-center gap-1.5 pt-8 font-mono text-[0.7rem] uppercase tracking-[0.16em] text-accent">
+                {t.cta}
+                <span class="pillar-arrow" aria-hidden="true">
+                  &rarr;
+                </span>
+              </span>
             </a>
           ) : (
-            <div class="bg-bg px-1 py-12 sm:px-7 lg:py-14">
-              <div class="pillar-glyph font-mono text-2xl text-gold" aria-hidden="true">
-                {t.glyph}
+            <div class="pillar is-soon relative flex flex-col bg-bg px-6 py-12 sm:px-7 lg:px-8 lg:py-16">
+              <span class="pillar-accent" aria-hidden="true" />
+              <div class="flex items-start justify-between">
+                <span
+                  class="pillar-glyph font-mono text-2xl text-gold"
+                  aria-hidden="true"
+                >
+                  {t.glyph}
+                </span>
+                <span class="pillar-index font-mono text-[0.7rem] tracking-[0.24em] text-muted">
+                  {t.n}
+                </span>
               </div>
-              <div class="mt-5 flex items-baseline gap-2.5">
-                <h2 class="font-display text-lg" style="font-weight:600">
-                  {t.title}
-                </h2>
-                {t.soon && (
-                  <span class="font-mono text-[0.6rem] uppercase tracking-[0.18em] text-muted">
-                    next
-                  </span>
-                )}
-              </div>
+              <h2 class="mt-6 font-display text-lg" style="font-weight:600">
+                {t.title}
+              </h2>
               <p class="mt-2.5 text-[0.95rem] leading-relaxed text-muted">
                 {t.body}
               </p>
+              <span class="mt-auto inline-flex items-center gap-2 pt-8 font-mono text-[0.7rem] uppercase tracking-[0.16em] text-muted">
+                <span class="pillar-soon-dot" aria-hidden="true" />
+                On the bench
+              </span>
             </div>
           )
         )
       }
+    </div>
+  </section>
+
+  <!-- Coda: a single distilled gold node closes the page -- a quiet full stop,
+       no copy. -->
+  <section
+    class="coda mx-auto max-w-6xl px-5 py-16 sm:px-8 lg:py-20"
+    data-reveal
+  >
+    <div class="coda-rule" aria-hidden="true">
+      <span class="coda-node"></span>
     </div>
   </section>
 </Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -154,9 +154,9 @@
   }
 
   /* Light-mode parity for the hero sigil: scope a warmer, brighter glow to the
-     mark alone (via local var overrides) so the "distilled gold" node still
-     visibly emits on parchment, without touching the tuned global tokens that
-     the other pages' art relies on. */
+     mark alone (via local var overrides) so the distilled gold node still
+     visibly emits on parchment, without touching the tuned global tokens the
+     other pages' art relies on. */
   [data-theme="light"] .hero-sigil {
     --glow-gold: 0.6;
     --glow-accent: 0.34;
@@ -216,6 +216,93 @@
   .pillar:hover .pillar-glyph {
     transform: translateY(-2px);
     text-shadow: 0 0 18px color-mix(in oklab, var(--gold) 55%, transparent);
+  }
+  /* Elevated triptych: each cell reads as an instrument panel. A top hairline
+     grows from center and lights emerald on hover, the index numeral warms,
+     and the CTA arrow steps forward. */
+  .pillar-accent {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 1px;
+    background: linear-gradient(to right, transparent, var(--accent), transparent);
+    opacity: 0;
+    transform: scaleX(0.35);
+    transition:
+      opacity 0.3s ease,
+      transform 0.35s ease;
+  }
+  .pillar:hover .pillar-accent {
+    opacity: 0.75;
+    transform: scaleX(1);
+  }
+  .pillar-index {
+    opacity: 0.5;
+    transition:
+      opacity 0.2s ease,
+      color 0.2s ease;
+  }
+  .pillar:hover .pillar-index {
+    opacity: 0.9;
+    color: var(--accent);
+  }
+  .pillar-cta {
+    opacity: 0.82;
+    transition: opacity 0.2s ease;
+  }
+  .pillar:hover .pillar-cta {
+    opacity: 1;
+  }
+  .pillar-arrow {
+    transition: transform 0.25s ease;
+  }
+  .pillar:hover .pillar-arrow {
+    transform: translateX(3px);
+  }
+  .pillar-soon-dot {
+    width: 0.42rem;
+    height: 0.42rem;
+    border-radius: 999px;
+    background: var(--gold);
+    box-shadow: 0 0 8px color-mix(in oklab, var(--gold) 55%, transparent);
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .pillar-soon-dot {
+      animation: bench-pulse 3.2s ease-in-out infinite;
+    }
+  }
+  @keyframes bench-pulse {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 1; }
+  }
+
+  /* Coda: a centered hairline distilling to one gold node -- the hero sigil's
+     transmutation payoff, re-stated as the page's closing beat. */
+  .coda-rule {
+    position: relative;
+    height: 1px;
+    width: min(26rem, 70%);
+    margin: 0 auto;
+    background: linear-gradient(to right, transparent, var(--line-strong), transparent);
+  }
+  .coda-node {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 7px;
+    height: 7px;
+    border-radius: 999px;
+    background: var(--gold);
+    transform: translate(-50%, -50%);
+    box-shadow: 0 0 12px color-mix(in oklab, var(--gold) 55%, transparent);
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .coda-node {
+      animation: coda-breathe 5s ease-in-out infinite;
+    }
+  }
+  @keyframes coda-breathe {
+    0%, 100% { box-shadow: 0 0 10px color-mix(in oklab, var(--gold) 45%, transparent); }
+    50% { box-shadow: 0 0 22px color-mix(in oklab, var(--gold) 78%, transparent); }
   }
 
   /* Entrance reveal: gentle assemble-on-load / on-scroll. The hidden start


### PR DESCRIPTION
## What

Rebuilds the landing page hero as a **chronosigil** — a UTC-driven kinetic SVG instrument — and finishes the supporting landing polish (triptych, coda, footer logo status).

### The chronosigil

Every line is a sinusoid over an arc, `r(θ,t) = R + Σ Aᵢ(t)·sin(nᵢθ + φᵢ(t))`, and every amplitude is itself a slow oscillator on incommensurate periods — the figure swells, subsides, and re-blooms rather than rotating rigidly.

- **Day**: a whisper-thin waveform track; a heavier arc develops around it as the 24h UTC day elapses, ending at a gold "now" node with a live sky glyph (◑ dawn / ☉ day / ◐ dusk / ☾ night)
- **Hour**: the main ring's harmonic count is set by the UTC hour and crossfades to the next across the hour; its stroke weight breathes and throbs once per real second
- **Kinetic numerals** (Futurist/Constructivist): hour laps the main ring in 12h, minute laps the inner ring in 1h, second orbits the core in 60s — each rides its ring's actual waveform, always upright, facing the reader
- **Hover reveal**: plain `HH:MM UTC` fades in under the gold core on hover only
- Native-framerate rAF; reduced-motion gets a static composed snapshot; SSR seeds a finished frame for no-JS; day/night theme aware

### Also

- Triptych pillars: index numerals, hover accent hairline, explicit CTAs
- Coda: a single breathing gold node closes the page
- Footer logo status variant: radial ripple instead of flat pulse

## Verification

- `astro build` passes (79 pages)
- Dark + light themes verified in-browser at multiple times of day; no console errors
- Hover tooltip verified with a real pointer hover