### PR TITLE
Landing: rotating hero pairs, authority voice, ciphers as a standing section

### DIFF
--- a/src/components/art/Avalanche.astro
+++ b/src/components/art/Avalanche.astro
@@ -1,0 +1,172 @@
+---
+/**
+ * Ciphers art: the avalanche effect. A lattice of bits; once per cycle the
+ * gold source bit flips and a wave of state-change cascades outward in a
+ * diamond wavefront (Manhattan distance — propagation looks digital, not
+ * organic), rewriting the grid. A scattered few bits are hardened — ringed
+ * in gold, they hold while everything around them flips. Security research
+ * in one loop: how systems break, and how they're built to hold.
+ *
+ * Pure CSS animation on theme tokens; reduced-motion is handled globally.
+ */
+const COLS = 13;
+const ROWS = 11;
+const STEP = 32;
+const X0 = 28;
+const Y0 = 30;
+const SIZE = 9;
+const ORIGIN = { c: 4, r: 5 };
+const PERIOD = 5.8; // s, shared by every bit so the wave stays coherent
+const SPREAD = 3.1; // s from source to the farthest corner
+
+const maxDist = Math.max(
+  ORIGIN.c + ORIGIN.r,
+  ORIGIN.c + (ROWS - 1 - ORIGIN.r),
+  COLS - 1 - ORIGIN.c + ORIGIN.r,
+  COLS - 1 - ORIGIN.c + (ROWS - 1 - ORIGIN.r)
+);
+
+// Deterministic "hardened" scatter — no randomness, stable builds.
+const isHard = (c: number, r: number) => (c * 31 + r * 17) % 19 === 0;
+
+const bits: { x: number; y: number; d: string }[] = [];
+const hard: { x: number; y: number }[] = [];
+for (let c = 0; c < COLS; c++) {
+  for (let r = 0; r < ROWS; r++) {
+    const x = X0 + c * STEP;
+    const y = Y0 + r * STEP;
+    if (c === ORIGIN.c && r === ORIGIN.r) continue;
+    if (isHard(c, r)) {
+      hard.push({ x, y });
+      continue;
+    }
+    const dist = Math.abs(c - ORIGIN.c) + Math.abs(r - ORIGIN.r);
+    bits.push({ x, y, d: ((dist / maxDist) * SPREAD).toFixed(2) });
+  }
+}
+const ox = X0 + ORIGIN.c * STEP;
+const oy = Y0 + ORIGIN.r * STEP;
+---
+
+<svg
+  viewBox="0 0 440 380"
+  class="art-svg"
+  role="img"
+  aria-label="A lattice of bits: one gold bit flips and an avalanche of state-change ripples across the grid, while a few hardened bits hold"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <defs>
+    <filter id="avGlow" x="-120%" y="-120%" width="340%" height="340%">
+      <feGaussianBlur stdDeviation="3"></feGaussianBlur>
+    </filter>
+  </defs>
+
+  <!-- the state: bits flipping as the wavefront passes -->
+  {
+    bits.map((b) => (
+      <rect
+        x={b.x - SIZE / 2}
+        y={b.y - SIZE / 2}
+        width={SIZE}
+        height={SIZE}
+        rx="2"
+        fill="var(--trace)"
+        class="av-bit"
+        style={`--d:${b.d}s;animation-duration:${PERIOD}s`}
+      />
+    ))
+  }
+
+  <!-- the hardened few: ringed in gold, they hold -->
+  {
+    hard.map((h) => (
+      <g>
+        <rect
+          x={h.x - SIZE / 2}
+          y={h.y - SIZE / 2}
+          width={SIZE}
+          height={SIZE}
+          rx="2"
+          fill="var(--gold)"
+          opacity="0.55"
+        />
+        <rect
+          x={h.x - SIZE / 2 - 3.5}
+          y={h.y - SIZE / 2 - 3.5}
+          width={SIZE + 7}
+          height={SIZE + 7}
+          rx="4"
+          fill="none"
+          stroke="var(--gold)"
+          stroke-width="1"
+          opacity="0.45"
+        />
+      </g>
+    ))
+  }
+
+  <!-- the source: the one flipped bit everything cascades from -->
+  <g class="av-core" style={`animation-duration:${PERIOD}s`}>
+    <circle cx={ox} cy={oy} r="10" fill="var(--gold)" opacity="0.4" filter="url(#avGlow)"
+    ></circle>
+    <rect
+      x={ox - 5.5}
+      y={oy - 5.5}
+      width="11"
+      height="11"
+      rx="2.5"
+      fill="var(--gold)"></rect>
+  </g>
+</svg>
+
+<style>
+  .av-bit {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation-name: avFlip;
+    animation-timing-function: ease-out;
+    animation-iteration-count: infinite;
+    animation-delay: var(--d);
+    opacity: 0.38;
+  }
+  .av-core {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation-name: avKick;
+    animation-timing-function: ease-out;
+    animation-iteration-count: infinite;
+  }
+  @keyframes avFlip {
+    0%,
+    100% {
+      fill: var(--trace);
+      opacity: 0.38;
+      transform: scale(1);
+    }
+    4% {
+      fill: var(--accent);
+      opacity: 1;
+      transform: scale(1.4);
+    }
+    11% {
+      fill: var(--accent);
+      opacity: 0.7;
+      transform: scale(1);
+    }
+    26% {
+      fill: var(--trace);
+      opacity: 0.38;
+    }
+  }
+  @keyframes avKick {
+    0% {
+      transform: scale(1.45);
+    }
+    12% {
+      transform: scale(1);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -44,4 +44,9 @@ const dev = defineCollection({
   schema: articleSchema,
 });
 
-export const collections = { posts, dev };
+const ciphers = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/ciphers" }),
+  schema: articleSchema,
+});
+
+export const collections = { posts, dev, ciphers };

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -43,6 +43,7 @@ const schemas = [
 const nav = [
   { label: "ML/AI", href: "/posts/" },
   { label: "Dev", href: "/dev/" },
+  { label: "Ciphers", href: "/ciphers/" },
   { label: "Topics", href: "/topics/" },
   { label: "About", href: "/about/" },
 ];

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,6 +1,9 @@
 import { getCollection, type CollectionEntry } from "astro:content";
 
-export type ArticleEntry = CollectionEntry<"posts"> | CollectionEntry<"dev">;
+export type ArticleEntry =
+  | CollectionEntry<"posts">
+  | CollectionEntry<"dev">
+  | CollectionEntry<"ciphers">;
 export type ArticleSection = ArticleEntry["collection"];
 
 export const sectionMeta: Record<
@@ -20,6 +23,13 @@ export const sectionMeta: Record<
     href: "/dev/",
     description:
       "Engineering notes on systems, infrastructure, agents, and tools that ship.",
+  },
+  ciphers: {
+    label: "Ciphers",
+    eyebrow: "ciphers",
+    href: "/ciphers/",
+    description:
+      "Security research notes: how systems break, how they hold, and the cryptography underneath.",
   },
 };
 
@@ -81,11 +91,12 @@ export function articleTopics(entry: ArticleEntry) {
 }
 
 export async function getPublishedArticles() {
-  const [posts, dev] = await Promise.all([
+  const [posts, dev, ciphers] = await Promise.all([
     getCollection("posts", ({ data }) => !data.draft),
     getCollection("dev", ({ data }) => !data.draft),
+    getCollection("ciphers", ({ data }) => !data.draft),
   ]);
-  return [...posts, ...dev].sort(byDateDesc);
+  return [...posts, ...dev, ...ciphers].sort(byDateDesc);
 }
 
 export function topicSlug(topic: string) {

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -4,12 +4,13 @@ import Article from "../layouts/Article.astro";
 import { articlePath, byDateDesc, type ArticleEntry } from "../lib/content";
 
 export async function getStaticPaths() {
-  const [posts, dev] = await Promise.all([
+  const [posts, dev, ciphers] = await Promise.all([
     getCollection("posts", ({ data }) => !data.draft),
     getCollection("dev", ({ data }) => !data.draft),
+    getCollection("ciphers", ({ data }) => !data.draft),
   ]);
 
-  return [...posts, ...dev].sort(byDateDesc).map((entry) => ({
+  return [...posts, ...dev, ...ciphers].sort(byDateDesc).map((entry) => ({
     params: { slug: articlePath(entry).replace(/^\/+|\/+$/g, "") },
     props: { entry },
   }));

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,7 +5,7 @@ import Aurora from "../components/art/Aurora.astro";
 
 <Base
   title="About · RenoCrypt"
-  description="About RenoCrypt, the Matrix Alchemy notebook for machine learning, AI, and engineering."
+  description="About RenoCrypt, Matrix Alchemy: technical writing on machine learning, AI, and engineering."
 >
   <section class="mx-auto max-w-6xl px-5 py-12 sm:px-8 lg:py-16">
     <div class="grid items-center gap-8 lg:grid-cols-[1fr_0.8fr] lg:gap-12">
@@ -22,13 +22,13 @@ import Aurora from "../components/art/Aurora.astro";
     <div class="max-w-3xl">
       <div class="article-body mt-10">
         <p>
-          RenoCrypt is a working notebook on machine learning, AI, and
+          RenoCrypt publishes technical writing on machine learning, AI, and
           engineering: the math underneath models, the systems that make them
           useful, and the craft of turning experiments into shipped tools.
         </p>
         <p>
           Written by Benji, whose background in physical chemistry and data
-          science shapes the notebook's bias toward first principles,
+          science shapes the writing's bias toward first principles,
           mathematical structure, and practical implementation.
         </p>
         <p>

--- a/src/pages/ciphers/index.astro
+++ b/src/pages/ciphers/index.astro
@@ -1,0 +1,70 @@
+---
+import { getCollection } from "astro:content";
+import Base from "../../layouts/Base.astro";
+import {
+  articleDescription,
+  articlePath,
+  articleTopics,
+  byDateDesc,
+  formatDate,
+  readingTime,
+  sectionMeta,
+} from "../../lib/content";
+import Avalanche from "../../components/art/Avalanche.astro";
+
+const articles = (
+  await getCollection("ciphers", ({ data }) => !data.draft)
+).sort(byDateDesc);
+const meta = sectionMeta.ciphers;
+---
+
+<Base title="Ciphers · RenoCrypt" description={meta.description}>
+  <section class="mx-auto max-w-6xl px-5 py-12 sm:px-8 lg:py-16">
+    <div class="grid items-center gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:gap-12">
+      <header class="max-w-3xl">
+        <p class="eyebrow">&rsaquo;&nbsp;&nbsp;{meta.eyebrow}</p>
+        <h1 class="mt-5 font-display text-[2.2rem] leading-tight sm:text-5xl">
+          Ciphers
+        </h1>
+        <p class="mt-5 max-w-2xl text-lg leading-relaxed text-muted">
+          {meta.description}
+        </p>
+      </header>
+      <div class="mx-auto w-full max-w-[380px]">
+        <Avalanche />
+      </div>
+    </div>
+
+    <div class="mt-10">
+      {
+        articles.map((entry) => (
+          <a class="article-card" href={articlePath(entry)}>
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[0.7rem] uppercase tracking-[0.14em] text-muted">
+              <span>{formatDate(entry.data.date)}</span>
+              <span>{readingTime(entry)} min read</span>
+            </div>
+            <h2 class="mt-3 max-w-3xl font-display text-2xl">
+              {entry.data.title}
+            </h2>
+            <p class="mt-2 max-w-2xl leading-relaxed text-muted">
+              {articleDescription(entry)}
+            </p>
+            <div class="mt-4 flex flex-wrap gap-2">
+              {articleTopics(entry).slice(0, 4).map((topic) => (
+                <span class="reno-chip">{topic}</span>
+              ))}
+            </div>
+          </a>
+        ))
+      }
+      {
+        articles.length === 0 && (
+          <p class="mt-4 font-mono text-sm tracking-[0.05em] text-muted">
+            <span class="text-accent">&rsaquo;</span>&nbsp;&nbsp;New notes land
+            here as they are written.
+          </p>
+        )
+      }
+    </div>
+  </section>
+</Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,10 +2,52 @@
 import Base from "../layouts/Base.astro";
 import HeroSigil from "../components/HeroSigil.astro";
 
-// The three threads. ML/AI is the substance today; security is the frontier
-// we're turning to next; engineering is the craft underneath both. Math is
+// Rotating hero headlines. Three complete thoughts in the site's voice —
+// what it is, why it exists, how it works — each plain enough to land on
+// first read. They share a length (~51 characters) so every variant wraps to
+// the same lines and the block never shifts. The first is canonical (SSR,
+// screen readers, no-JS, reduced-motion); the others surface one at a time
+// with a word-level stagger.
+// Voice: the authority claim. Every headline is a credibility statement,
+// every lede says what backs it up. The header carries the name; the copy
+// never repeats it.
+const heroLines = [
+  [
+    { w: "Technical" },
+    { w: "depth" },
+    { w: "you" },
+    { w: "can" },
+    { w: "build", accent: true },
+    { w: "on", dot: true },
+  ],
+  [
+    { w: "Every" },
+    { w: "claim" },
+    { w: "comes" },
+    { w: "with" },
+    { w: "the" },
+    { w: "math", accent: true, dot: true },
+  ],
+  [
+    { w: "One" },
+    { w: "source," },
+    { w: "the" },
+    { w: "entire" },
+    { w: "stack", accent: true, dot: true },
+  ],
+];
+
+// Each headline's companion lede rotates with it and continues its thought.
+// Kept to one measure so every variant wraps alike and the CTAs never move.
+const heroLedes = [
+  "Long-form writing on machine learning, systems, and security — precise enough to cite, practical enough to ship.",
+  "Derivations, benchmarks, and working code are part of every piece, so results can be verified, not just quoted.",
+  "Model internals, systems engineering, and security research as one body of work — consistent from the mathematics to the deployed system.",
+];
+
+// The three threads, all standing: models, machines, ciphers. Math is
 // implicit ("first principles"), explained where a piece needs it, not a
-// thread of its own. Live sections link; the coming one is a statement.
+// thread of its own.
 const threads = [
   {
     n: "01",
@@ -27,8 +69,9 @@ const threads = [
     n: "03",
     glyph: "⊕",
     title: "The ciphers",
-    body: "Cryptography and the hard edges of systems built to be trusted.",
-    soon: true,
+    body: "Security from both sides: how systems get broken, and how to build ones that hold.",
+    href: "/ciphers/",
+    cta: "Read Ciphers",
   },
 ];
 ---
@@ -44,22 +87,42 @@ const threads = [
           <span class="text-accent">&rsaquo;</span>&nbsp;&nbsp;matrix alchemy
         </p>
         <h1
-          class="mt-5 text-balance font-display text-[2.05rem] leading-[1.1] tracking-[-0.025em] sm:text-[3.4rem] sm:leading-[1.04]"
+          class="hero-rotator mt-5 font-display text-[2.05rem] leading-[1.1] tracking-[-0.025em] sm:text-[3.4rem] sm:leading-[1.04]"
           style="font-weight:600;--reveal-delay:70ms"
           data-reveal
+          data-hero-rotator
         >
-          Notes on the models, the machines, and the <span class="text-accent"
-            >ciphers</span
-          ><span class="text-gold">.</span>
+          {
+            heroLines.map((line, li) => (
+              <span
+                class={`hero-line${li === 0 ? " is-active" : ""}`}
+                aria-hidden={li === 0 ? undefined : "true"}
+                data-hero-line
+              >
+                {/* prettier-ignore */}
+                {line.map((t, wi) => (
+                  <Fragment><span class="hw" style={`--wi:${wi}`}><span class={t.accent ? "text-accent" : t.gold ? "text-gold" : ""}>{t.w}</span>{t.dot && <span class="text-gold">.</span>}</span>{" "}</Fragment>
+                ))}
+              </span>
+            ))
+          }
         </h1>
         <p
-          class="mt-6 max-w-md text-lg leading-relaxed text-fg-soft"
+          class="hero-ledes mt-6 max-w-md text-lg leading-relaxed text-fg-soft"
           style="--reveal-delay:140ms"
           data-reveal
         >
-          RenoCrypt is a working notebook on machine learning and the systems
-          that run it. Cybersecurity is where it's heading next. Written in the
-          open, from first principles to production.
+          {
+            heroLedes.map((lede, li) => (
+              <span
+                class={`hero-lede${li === 0 ? " is-active" : ""}`}
+                aria-hidden={li === 0 ? undefined : "true"}
+                data-hero-lede
+              >
+                {lede}
+              </span>
+            ))
+          }
         </p>
         <div
           class="mt-8 flex flex-wrap items-center gap-3"
@@ -70,7 +133,7 @@ const threads = [
             href="/posts/"
             class="cta-primary rounded-md bg-accent px-5 py-2.5 font-mono text-[0.8rem] uppercase tracking-[0.14em] text-bg"
           >
-            Read the writing
+            Explore the work
           </a>
           <a
             href="/topics/"
@@ -102,67 +165,40 @@ const threads = [
     <div class="rule"></div>
     <div class="grid gap-px overflow-hidden bg-line sm:grid-cols-3" data-reveal>
       {
-        threads.map((t) =>
-          t.href ? (
-            <a
-              href={t.href}
-              class="pillar group relative flex flex-col bg-bg px-6 py-12 sm:px-7 lg:px-8 lg:py-16"
-            >
-              <span class="pillar-accent" aria-hidden="true" />
-              <div class="flex items-start justify-between">
-                <span
-                  class="pillar-glyph font-mono text-2xl text-gold"
-                  aria-hidden="true"
-                >
-                  {t.glyph}
-                </span>
-                <span class="pillar-index font-mono text-[0.7rem] tracking-[0.24em] text-muted">
-                  {t.n}
-                </span>
-              </div>
-              <h2
-                class="pillar-title mt-6 font-display text-lg"
-                style="font-weight:600"
+        threads.map((t) => (
+          <a
+            href={t.href}
+            class="pillar group relative flex flex-col bg-bg px-6 py-12 sm:px-7 lg:px-8 lg:py-16"
+          >
+            <span class="pillar-accent" aria-hidden="true"></span>
+            <div class="flex items-start justify-between">
+              <span
+                class="pillar-glyph font-mono text-2xl text-gold"
+                aria-hidden="true"
               >
-                {t.title}
-              </h2>
-              <p class="mt-2.5 text-[0.95rem] leading-relaxed text-muted">
-                {t.body}
-              </p>
-              <span class="pillar-cta mt-auto inline-flex items-center gap-1.5 pt-8 font-mono text-[0.7rem] uppercase tracking-[0.16em] text-accent">
-                {t.cta}
-                <span class="pillar-arrow" aria-hidden="true">
-                  &rarr;
-                </span>
+                {t.glyph}
               </span>
-            </a>
-          ) : (
-            <div class="pillar is-soon relative flex flex-col bg-bg px-6 py-12 sm:px-7 lg:px-8 lg:py-16">
-              <span class="pillar-accent" aria-hidden="true" />
-              <div class="flex items-start justify-between">
-                <span
-                  class="pillar-glyph font-mono text-2xl text-gold"
-                  aria-hidden="true"
-                >
-                  {t.glyph}
-                </span>
-                <span class="pillar-index font-mono text-[0.7rem] tracking-[0.24em] text-muted">
-                  {t.n}
-                </span>
-              </div>
-              <h2 class="mt-6 font-display text-lg" style="font-weight:600">
-                {t.title}
-              </h2>
-              <p class="mt-2.5 text-[0.95rem] leading-relaxed text-muted">
-                {t.body}
-              </p>
-              <span class="mt-auto inline-flex items-center gap-2 pt-8 font-mono text-[0.7rem] uppercase tracking-[0.16em] text-muted">
-                <span class="pillar-soon-dot" aria-hidden="true" />
-                On the bench
+              <span
+                class="pillar-index font-mono text-[0.7rem] tracking-[0.24em] text-muted"
+              >
+                {t.n}
               </span>
             </div>
-          )
-        )
+            <h2
+              class="pillar-title mt-6 font-display text-lg"
+              style="font-weight:600"
+            >
+              {t.title}
+            </h2>
+            <p class="mt-2.5 text-[0.95rem] leading-relaxed text-muted">
+              {t.body}
+            </p>
+            <span class="pillar-cta mt-auto inline-flex items-center gap-1.5 pt-8 font-mono text-[0.7rem] uppercase tracking-[0.16em] text-accent">
+              {t.cta}
+              <span class="pillar-arrow" aria-hidden="true">&rarr;</span>
+            </span>
+          </a>
+        ))
       }
     </div>
   </section>
@@ -177,4 +213,31 @@ const threads = [
       <span class="coda-node"></span>
     </div>
   </section>
+
+  <!-- Rotate the hero headline. Screen readers keep the canonical first line
+       (aria-hidden never changes); motion respects reduced-motion by simply
+       never starting; the tab being hidden pauses the cycle. -->
+  <script>
+    const rot = document.querySelector("[data-hero-rotator]");
+    const motionOK = window.matchMedia(
+      "(prefers-reduced-motion: no-preference)"
+    ).matches;
+    if (rot && motionOK) {
+      const lines = [...rot.querySelectorAll<HTMLElement>("[data-hero-line]")];
+      const ledes = [
+        ...document.querySelectorAll<HTMLElement>("[data-hero-lede]"),
+      ];
+      if (lines.length > 1) {
+        let i = 0;
+        setInterval(() => {
+          if (document.hidden) return;
+          lines[i].classList.remove("is-active");
+          ledes[i]?.classList.remove("is-active");
+          i = (i + 1) % lines.length;
+          lines[i].classList.add("is-active");
+          ledes[i]?.classList.add("is-active");
+        }, 7000);
+      }
+    }
+  </script>
 </Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -162,6 +162,73 @@
     --glow-accent: 0.34;
   }
 
+  /* Rotating hero headline: variants stack in one grid cell (the tallest
+     reserves the height, so nothing below ever shifts). The active line's
+     words rise into focus one by one; the outgoing line falls away as a
+     whole. Word delay comes from --wi set inline per word. */
+  .hero-rotator {
+    display: grid;
+  }
+  .hero-line {
+    grid-area: 1 / 1;
+    display: block;
+    text-wrap: balance;
+  }
+  .hero-line .hw {
+    display: inline-block;
+    opacity: 0;
+    transform: translateY(0.35em);
+    filter: blur(7px);
+    transition:
+      opacity 0.35s ease,
+      transform 0.35s ease,
+      filter 0.35s ease;
+    transition-delay: 0s;
+  }
+  .hero-line.is-active .hw {
+    opacity: 1;
+    transform: none;
+    filter: none;
+    transition-duration: 0.55s;
+    transition-delay: calc(120ms + var(--wi) * 60ms);
+  }
+  .hero-line:not(.is-active) {
+    pointer-events: none;
+    user-select: none;
+  }
+  /* The headline's companion lede: same stacked-grid trick, but the change
+     is quiet — a whole-paragraph settle that arrives a beat after the
+     headline's words have begun landing. */
+  .hero-ledes {
+    display: grid;
+  }
+  .hero-lede {
+    grid-area: 1 / 1;
+    display: block;
+    opacity: 0;
+    transform: translateY(0.35em);
+    transition:
+      opacity 0.4s ease,
+      transform 0.4s ease;
+    transition-delay: 0s;
+    pointer-events: none;
+    user-select: none;
+  }
+  .hero-lede.is-active {
+    opacity: 1;
+    transform: none;
+    transition-duration: 0.6s;
+    transition-delay: 0.4s;
+    pointer-events: auto;
+    user-select: auto;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .hero-line .hw,
+    .hero-lede {
+      transition: none;
+    }
+  }
+
   /* CTAs: lift + emit light on hover, and acknowledge the press. */
   .cta-primary {
     transition:


### PR DESCRIPTION
## What

### Hero: rotating matched pairs, authority voice
- Headline + companion lede rotate **together** — the headline composes word by word, its lede settles in a beat later. Three pairs, each an authority claim backed by its lede:
  1. *Technical depth you can build on.* — "Long-form writing on machine learning, systems, and security — precise enough to cite, practical enough to ship."
  2. *Every claim comes with the math.* — "Derivations, benchmarks, and working code are part of every piece, so results can be verified, not just quoted."
  3. *One source, the entire stack.* — "Model internals, systems engineering, and security research as one body of work — consistent from the mathematics to the deployed system."
- Variants share one measure and stack in a reserved-height grid — measured pixel-identical, so CTAs never move during rotation.
- Words are real text nodes now (copy/paste and screen readers get proper spacing). Screen readers/no-JS/reduced-motion get the canonical pair statically.
- Primary CTA: "Explore the work". No self-labeling anywhere ("blog"/"journal"/"notebook" purged); the copy never repeats the site name.

### Ciphers, treated as already here
- New `ciphers` content collection (same schema as posts/dev) wired into article routes, RSS, topics, and section metadata.
- `/ciphers/` index page matching `/dev/`, with a quiet zero-state until the first entry lands. Ciphers added to the site nav; the landing triptych's third panel is a live link (the "On the bench" soon-state is gone).
- **New Avalanche art**: a bit-lattice where one gold source bit flips and a diamond wavefront cascades across the grid while gold-ringed hardened bits hold — the avalanche criterion as the section's emblem. Pure CSS on theme tokens, deterministic layout, reduced-motion safe.
- Ciphers framed as security research (attack + defense), not just cryptography.

## Verification
- `astro build` passes (80 pages, /ciphers/ included)
- Dark + light themes verified in-browser; console clean throughout
- Headline/lede variant heights measured identical at multiple viewports (desktop/tablet/phone)
- Pair rotation, hover tooltip on the chronosigil, and Avalanche animation all verified live